### PR TITLE
Fix crash on iOS 16/17 when an evaluated script returns no value

### DIFF
--- a/Sources/LightweightCharts/Implementations/WebView.swift
+++ b/Sources/LightweightCharts/Implementations/WebView.swift
@@ -14,6 +14,15 @@ class WebView: WKWebView {
     
 }
 
+/// Carries an `evaluateJavaScript` result across the continuation boundary.
+/// Both the completion handler and the caller are `@MainActor`-isolated, so the value
+/// never actually leaves its isolation domain.
+private struct JavaScriptResultBox: @unchecked Sendable {
+
+    let value: Any?
+
+}
+
 // MARK: - JavaScriptEvaluator
 extension WebView: JavaScriptEvaluator {
 
@@ -63,7 +72,20 @@ extension WebView: JavaScriptEvaluator {
     public func evaluateScript(_ script: String) async throws(JavaScriptBridgeError) -> Any? {
         try JavaScriptBridgeError.checkCancellation()
         do {
-            let result = try await evaluateJavaScript(script, contentWorld: .page)
+            // NB: the async overlay of `evaluateJavaScript(_:in:contentWorld:)` traps on
+            // iOS 16/17 when the script evaluates to `undefined`: WebKit calls the completion
+            // handler with (nil, nil) and the overlay force-unwraps the result. Bridging the
+            // completion handler by hand keeps a missing value as `nil`.
+            let box: JavaScriptResultBox = try await withCheckedThrowingContinuation { continuation in
+                evaluateJavaScript(script) { value, error in
+                    if let error {
+                        continuation.resume(throwing: error)
+                    } else {
+                        continuation.resume(returning: JavaScriptResultBox(value: value))
+                    }
+                }
+            }
+            let result = box.value
             try JavaScriptBridgeError.checkCancellation()
             return result
         } catch {


### PR DESCRIPTION
`WebView.evaluateScript` used the async overlay of `evaluateJavaScript(_:in:contentWorld:)`. Its Swift signature is `Any?`, but on iOS 16/17 the overlay goes through a completion handler thunk whose result type is a non-optional `Any` and force-unwraps it.

WebKit invokes that completion handler with (nil, nil) whenever the script evaluates to `undefined`, so the thunk traps with EXC_BREAKPOINT. Two of the library's own bootstrap scripts hit this on every chart creation: `wrapper_functions.js` (only function declarations) and the generated createChart script (only `var` declarations). On iOS 18+ the overlay no longer force-unwraps, which is why the crash is confined to older systems.

Bridge the completion handler by hand so that a missing value stays `nil`. The result travels in a small box because Swift 6 strict concurrency rejects passing a non-`Sendable` `Any?` into `CheckedContinuation.resume(returning:)`, even though both ends are `@MainActor`-isolated.

`evaluate(script:resultType:)` now also reports a proper `invalidResult` error instead of trapping when `JSON.stringify` yields `undefined`.